### PR TITLE
fix: empty rows resulted in unhandled error - repaired by omitting

### DIFF
--- a/src/js/airtable.js
+++ b/src/js/airtable.js
@@ -51,8 +51,11 @@ function generateDownload(json, type) {
 
   let csvColumns = [];
 
-  const result = json.rows.map((row) => {
+  let result = json.rows.map((row) => {
     const rowData = {};
+
+    if (!row.cellValuesByColumnId)
+      return undefined;
 
     for (let [key, value] of Object.entries(row.cellValuesByColumnId)) {
       const column = columns[key];
@@ -88,6 +91,8 @@ function generateDownload(json, type) {
 
     return rowData;
   });
+
+  result = result.filter(entry => entry !== undefined);
 
   let blob;
   let filename;


### PR DESCRIPTION
fixes #23 

The issue is with empty rows, that don't have the `cellValuesByColumnId`. The PR fixes this by omitting affected rows. I know this was the problem since we solved it during pairing with @LostInDarkMath.